### PR TITLE
Ensure AI feedback matches CV language

### DIFF
--- a/cv_feedback_plugin
+++ b/cv_feedback_plugin
@@ -965,6 +965,10 @@ Please upload your CV in DOCX or in a PDF with selectable text (OCR). You can al
                         'content' =>
 "You are a senior recruiter. Provide brief, clear, and actionable feedback.
 
+LANGUAGE:
+- Detect the primary language of the CV content provided by the user.
+- Respond fully and exclusively in that language (no mixing languages, no translations unless the CV text is bilingual and overwhelmingly in one language).
+
 FORMAT:
 - Respond ONLY as a valid HTML fragment (no <html> or <body>).
 - Use <h2> and <h3> for section headings (do not use <strong> in titles).
@@ -1023,6 +1027,7 @@ CRITICAL RULES
 - Adapt the feedback to the role and sector above.
 - Do not invent achievements, companies or technologies.
 - $ban_clause
+- Identify the main language used in the CV content and respond entirely in that language. Do not switch languages or translate to another language unless the CV itself mixes languages and one is clearly dominant.
 - Return HTML ONLY (no code blocks, no ```).
 - Section headings must be in <h2> or <h3> (already bold).
 - Content should be in <p>, <ul>, <ol>, <li> — no <strong> or <em>.


### PR DESCRIPTION
## Summary
- instruct the AI system message to detect the CV language and answer entirely in that language
- reinforce the language-matching requirement in the user prompt rules so feedback stays consistent with the uploaded CV

## Testing
- php -l cv_feedback_plugin

------
https://chatgpt.com/codex/tasks/task_e_68d1bbdc88a4832a9b96a5a1942d85bc