### PR TITLE
Support vacancy selection via query params

### DIFF
--- a/cv_feedback_plugin
+++ b/cv_feedback_plugin
@@ -402,20 +402,28 @@ JS;
         $atts = array_change_key_case((array) $atts, CASE_LOWER);
         $defaults = [];
 
-        foreach (['default_vacancy', 'vacancy', 'vacancy_id'] as $key) {
-            if (!empty($atts[$key])) {
-                $defaults['vacancy'] = intval($atts[$key]);
-                break;
+        $request_vacancy = $this->get_vacancy_from_request();
+        if ($request_vacancy) {
+            $defaults['vacancy'] = $request_vacancy;
+        }
+
+        if (empty($defaults['vacancy'])) {
+            foreach (['default_vacancy', 'vacancy', 'vacancy_id'] as $key) {
+                if (empty($atts[$key])) {
+                    continue;
+                }
+                $maybe = $this->resolve_vacancy_id($atts[$key]);
+                if ($maybe) {
+                    $defaults['vacancy'] = $maybe;
+                    break;
+                }
             }
         }
 
         if (empty($defaults['vacancy']) && !empty($atts['vacancy_title'])) {
-            $title = sanitize_text_field($atts['vacancy_title']);
-            if ($title !== '') {
-                $vac = get_page_by_title($title, 'OBJECT', 'post');
-                if ($vac && isset($vac->ID)) {
-                    $defaults['vacancy'] = intval($vac->ID);
-                }
+            $maybe = $this->resolve_vacancy_id($atts['vacancy_title']);
+            if ($maybe) {
+                $defaults['vacancy'] = $maybe;
             }
         }
 
@@ -436,6 +444,60 @@ JS;
         }
         $value = strtolower(trim((string) $value));
         return in_array($value, ['1', 'true', 'yes', 'y', 'on'], true);
+    }
+
+    private function resolve_vacancy_id($value) {
+        if (is_numeric($value)) {
+            $id = absint($value);
+            if ($id && get_post_type($id) === 'post') {
+                return $id;
+            }
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return 0;
+        }
+
+        $title = sanitize_text_field($value);
+        if ($title !== '') {
+            $vacancy = get_page_by_title($title, 'OBJECT', 'post');
+            if ($vacancy && isset($vacancy->ID) && get_post_type($vacancy->ID) === 'post') {
+                return intval($vacancy->ID);
+            }
+        }
+
+        $slug = sanitize_title($value);
+        if ($slug !== '') {
+            $vacancy = get_page_by_path($slug, 'OBJECT', 'post');
+            if ($vacancy && isset($vacancy->ID) && get_post_type($vacancy->ID) === 'post') {
+                return intval($vacancy->ID);
+            }
+        }
+
+        return 0;
+    }
+
+    private function get_vacancy_from_request() {
+        $keys = ['vacancy', 'vacancy_id', 'vacancy_title', 'vacancy_slug'];
+        foreach ($keys as $key) {
+            if (!isset($_GET[$key])) {
+                continue;
+            }
+            $raw = wp_unslash($_GET[$key]);
+            if (is_array($raw)) {
+                $raw = reset($raw);
+            }
+            if ($raw === '') {
+                continue;
+            }
+            $maybe = $this->resolve_vacancy_id($raw);
+            if ($maybe) {
+                return $maybe;
+            }
+        }
+
+        return 0;
     }
 
     private function render_form($errors = [], $old = [], $register_only = false, $defaults = []) {


### PR DESCRIPTION
## Summary
- allow the CV feedback form to read vacancy defaults from the current request query parameters
- add helpers to resolve vacancy IDs from IDs, titles or slugs so new vacancies are preselected reliably

## Testing
- php -l cv_feedback_plugin

------
https://chatgpt.com/codex/tasks/task_e_68d51f507ab0832aa2f287faadacac39